### PR TITLE
fix: [poap] strategies

### DIFF
--- a/src/strategies/poap-with-weight/index.ts
+++ b/src/strategies/poap-with-weight/index.ts
@@ -3,7 +3,7 @@ import { subgraphRequest } from '../../utils';
 import examplesFile from './examples.json';
 
 export const author = 'gawainb';
-export const version = '1.1.0';
+export const version = '1.2.0';
 export const examples = examplesFile;
 
 const POAP_API_ENDPOINT_URL = {
@@ -14,7 +14,6 @@ const POAP_API_ENDPOINT_URL = {
 const getTokenSupply = {
   tokens: {
     __args: {
-      block: undefined as undefined | { number: number },
       where: {
         id_in: undefined
       }
@@ -46,7 +45,7 @@ export async function strategy(
     (token) => token.id
   );
   if (snapshot !== 'latest') {
-    getTokenSupply.tokens.__args.block = { number: snapshot };
+    getTokenSupply.tokens.__args['block'] = { number: snapshot };
   }
   const supplyResponse = await subgraphRequest(
     POAP_API_ENDPOINT_URL[network],

--- a/src/strategies/poap/README.md
+++ b/src/strategies/poap/README.md
@@ -2,12 +2,19 @@
 
 Each POAP is implemented as an erc721 with a max supply tokens.
 
-This strategy returns the number of POAP ERC721 NFTs owned by each account.
+If no `eventIds` are passed, then this strategy returns the number of tokens owned by each account. Otherwise, it returns the number of tokens per account where the token's event id is included in `eventIds`.
 
-Here is an example of parameters:
+Here are some examples of parameters:
 
 ```json
 {
   "symbol": "POAP"
+}
+```
+
+```json
+{
+  "symbol": "POAP",
+  "eventIds": ["1213", "1293"]
 }
 ```

--- a/src/strategies/poap/README.md
+++ b/src/strategies/poap/README.md
@@ -2,7 +2,7 @@
 
 Each POAP is implemented as an erc721 with a max supply tokens.
 
-If no `eventIds` are passed, then this strategy returns the number of tokens owned by each account. Otherwise, it returns the number of tokens per account where the token's event id is included in `eventIds`.
+If no `eventIds` are passed, then this strategy returns the number of tokens owned by each account. Otherwise, it returns the number of tokens per account where the event id is included in `eventIds`.
 
 Here are some examples of parameters:
 

--- a/src/strategies/poap/examples.json
+++ b/src/strategies/poap/examples.json
@@ -4,7 +4,8 @@
     "strategy": {
       "name": "poap",
       "params": {
-        "symbol": "POAP"
+        "symbol": "POAP",
+        "eventIds": ["1213", "1293"]
       }
     },
     "network": "100",
@@ -13,6 +14,6 @@
       "0x00ac36c51500e900ab0f4e692fc1338cf70571b2",
       "0xdd6f702c2907ce401888d993d7dc185e7a824466"
     ],
-    "snapshot": 13040844
+    "snapshot": 25283078
   }
 ]

--- a/src/strategies/poap/index.ts
+++ b/src/strategies/poap/index.ts
@@ -1,27 +1,105 @@
 import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
 import { strategy as erc721Strategy } from '../erc721';
 
 export const author = 'greenealexander';
-export const version = '1.0.0';
+export const version = '2.0.0';
+
+// subgraph query in filter has max length of 500
+const EVENT_IDS_LIMIT = 500;
+const POAP_API_ENDPOINT_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/poap-xyz/poap',
+  '100': 'https://api.thegraph.com/subgraphs/name/poap-xyz/poap-xdai'
+};
+// subgraph query in filter has max length of 500
+const MAX_ACCOUNTS_IN_QUERY = 500;
 
 export async function strategy(
   space,
   network,
   provider,
   addresses,
-  _options,
+  options,
   snapshot
 ) {
-  const results = await erc721Strategy(
-    space,
-    network,
-    provider,
-    addresses,
-    { address: '0x22C1f6050E56d2876009903609a2cC3fEf83B415' },
-    snapshot
-  );
-  return addresses.reduce((map, address) => {
-    map[getAddress(address)] = results[address] ?? 0;
+  const shouldFilterForEvents = (options?.eventIds?.length ?? 0) > 0;
+
+  if (!shouldFilterForEvents) {
+    const results = await erc721Strategy(
+      space,
+      network,
+      provider,
+      addresses,
+      { address: '0x22C1f6050E56d2876009903609a2cC3fEf83B415' },
+      snapshot
+    );
+    return addresses.reduce((map, address) => {
+      map[getAddress(address)] = results[address] ?? 0;
+      return map;
+    }, {});
+  }
+
+  if (shouldFilterForEvents && options.eventIds.length > EVENT_IDS_LIMIT) {
+    throw new Error(`Max number (${EVENT_IDS_LIMIT}) of event ids exceeded`);
+  }
+
+  const addressesMap = addresses.reduce((map, address) => {
+    map[getAddress(address)] = 0;
     return map;
   }, {});
+  const lowercaseAddresses = Object.keys(addressesMap).map((address) =>
+    address.toLowerCase()
+  );
+
+  // batch addresses to query into slices of MAX_ACCOUNTS_IN_QUERY size
+  const lowercaseAddressBatches: string[][] = [];
+  for (let i = 0; i < lowercaseAddresses.length; i += MAX_ACCOUNTS_IN_QUERY) {
+    const slice = lowercaseAddresses.slice(i, i + MAX_ACCOUNTS_IN_QUERY);
+    lowercaseAddressBatches.push(slice);
+  }
+
+  const query = {
+    accounts: {
+      __args: {
+        where: {
+          id_in: [] as string[]
+        }
+      },
+      id: true,
+      tokens: {
+        __args: {
+          where: {
+            event_in: options.eventIds
+          }
+        },
+        id: true
+      }
+    }
+  };
+  if (snapshot !== 'latest') {
+    query.accounts.__args['block'] = { number: snapshot };
+  }
+
+  const results = await Promise.allSettled<{
+    accounts: { id: string; tokens?: { id: string }[] }[];
+  }>(
+    lowercaseAddressBatches.map((addresses) => {
+      query.accounts.__args.where.id_in = addresses;
+      return subgraphRequest(POAP_API_ENDPOINT_URL[network], query);
+    })
+  );
+
+  for (const supplyResponse of results) {
+    if (supplyResponse.status === 'rejected') continue;
+
+    for (const account of supplyResponse.value.accounts) {
+      const accountId = getAddress(account.id);
+
+      if (addressesMap[accountId] === undefined) continue;
+
+      addressesMap[accountId] = account.tokens?.length ?? 0;
+    }
+  }
+
+  return addressesMap;
 }


### PR DESCRIPTION
Fixes some poap strategies

Changes proposed in this pull request:
- 1:1 strategy should also be capable of only counting specific tokens per their event id
  - will use the `erc721` strategy if no event ids passed
- with-weight block/snapshot param may not have been returning expected results